### PR TITLE
Fix all asciidoc warnings by including attributes.adoc

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,0 +1,3 @@
+:project-version: ${release.current-version}
+
+:examples-dir: ./../examples/


### PR DESCRIPTION
Asciidoc interprets strings like ${project-version} as attributes and then issues a WARN during the build that it will skip reference to a missing attribute. This PR adds an attributes.adoc file.

Proof of all warnings gone:
<img width="632" alt="image" src="https://github.com/quarkiverse/quarkus-jdbc-clickhouse/assets/11942401/47ce1d9c-8ef7-4b16-8e34-1f4e5dd8f653">

Proof of warnings before this PR:
<img width="853" alt="image" src="https://github.com/quarkiverse/quarkus-jdbc-clickhouse/assets/11942401/0fce0859-ba73-480b-b564-8f5598b2f5f6">
